### PR TITLE
chore: added news sites

### DIFF
--- a/src/linkparser.py
+++ b/src/linkparser.py
@@ -40,6 +40,24 @@ class LinkParser():
     'x.com': {
       'type': 'social',
       'replacement': 'vxtwitter.com'
+    },
+    'expressnews.com': {
+      'type': 'news'
+    },
+    'newsweek.com': {
+      'type': 'news'
+    },
+    'forbes.com': {
+      'type': 'news'
+    },
+    'haaretz.com': {
+      'type': 'news'
+    },
+    'latimes.com': {
+      'type': 'news'
+    },
+    'houstonchronicle.com': {
+      'type': 'news'
     }
   }
   


### PR DESCRIPTION
Enhancements to link categorization:

* [`src/linkparser.py`](diffhunk://#diff-ddb8ecd7d2cfed2b037754a1d2772cd2049237db26879c81df087d3541a9cf51R43-R60): Added `expressnews.com`, `newsweek.com`, `forbes.com`, `haaretz.com`, `latimes.com`, and `houstonchronicle.com` to the list of domains categorized as news.